### PR TITLE
Allow authn request without relayState if relayState is empty

### DIFF
--- a/toolkit/src/main/java/com/onelogin/saml2/Auth.java
+++ b/toolkit/src/main/java/com/onelogin/saml2/Auth.java
@@ -213,7 +213,8 @@ public class Auth {
 	 * Initiates the SSO process.
 	 *
 	 * @param returnTo
-	 *				The target URL the user should be returned to after login.
+	 *				The target URL the user should be returned to after login (relayState).
+	 *				Will be a self-routed URL when null, or not be appended at all when an empty string is provided
 	 * @param forceAuthn
 	 *				When true the AuthNRequest will set the ForceAuthn='true'
 	 * @param isPassive
@@ -237,7 +238,10 @@ public class Auth {
 		} else {
 			relayState = returnTo;
 		}
-		parameters.put("RelayState", relayState);
+
+		if (!relayState.isEmpty()) {
+			parameters.put("RelayState", relayState);
+		}
 
 		if (settings.getAuthnRequestsSigned()) {
 			String sigAlg = settings.getSignatureAlgorithm();
@@ -267,7 +271,8 @@ public class Auth {
 	 * Initiates the SSO process.
 	 *
 	 * @param returnTo 
-     *				The target URL the user should be returned to after login.
+     *				The target URL the user should be returned to after login (relayState).
+	 *				Will be a self-routed URL when null, or not be appended at all when an empty string is provided
      *
 	 * @throws IOException
 	 */

--- a/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
+++ b/toolkit/src/test/java/com/onelogin/saml2/test/AuthTest.java
@@ -965,6 +965,33 @@ public class AuthTest {
 
 	/**
 	 * Tests the login method of Auth
+	 * Case: Login with empty relayState - no relayState appended
+	 *
+	 * @throws SettingsException
+	 * @throws IOException
+	 * @throws URISyntaxException
+	 *
+	 * @see com.onelogin.saml2.Auth#login
+	 */
+	@Test
+	public void testLoginWithoutRelayState() throws IOException, SettingsException, URISyntaxException {
+		HttpServletRequest request = mock(HttpServletRequest.class);
+		HttpServletResponse response = mock(HttpServletResponse.class);
+		when(request.getScheme()).thenReturn("http");
+		when(request.getServerPort()).thenReturn(8080);
+		when(request.getServerName()).thenReturn("localhost");
+		when(request.getRequestURI()).thenReturn("/initial.jsp");
+
+		Saml2Settings settings = new SettingsBuilder().fromFile("config/config.my.properties").build();
+		settings.setAuthnRequestsSigned(false);
+
+		Auth auth = new Auth(settings, request, response);
+		auth.login("");
+		verify(response).sendRedirect(matches("https:\\/\\/pitbulk.no-ip.org\\/simplesaml\\/saml2\\/idp\\/SSOService.php\\?SAMLRequest=(.)*"));
+	}
+
+	/**
+	 * Tests the login method of Auth
 	 * Case: Signed Login but no sp key
 	 *
 	 * @throws SettingsException


### PR DESCRIPTION
Currently it's not possible to have an authn request without a relayState. When a null relayState is provided, then a self routed URL is used instead. If an empty string is provided, then relayState is appended as a query parameter without value. A request without a relayState is a valid case and relayState without value does not work ie in ADFS (it results in an MSIS7000 error).

To mitigate this without changing the API too much I've changed login to treat an empty returnTo (relayState) parameter as no relay state. A null returnTo will still result in a self routed URL. I also added a test case for this scenario and extended the Javadocs to inform about the behavior.
